### PR TITLE
book-a-demo (test Calendly widget) tracking

### DIFF
--- a/app/book-a-demo/client.tsx
+++ b/app/book-a-demo/client.tsx
@@ -12,7 +12,8 @@ export default function BookADemoClient() {
       contact: "/contact",
       meetingConfirmed: "/meeting-confirmed",
     },
-    calendlyUrl: "https://calendly.com/d/cw2v-vw3-j2z",
+    calendlyUrl:
+      "https://calendly.com/d/csww-rc4-9v6/test-version?hide_event_type_details=1&hide_gdpr_banner=1",
   };
 
   return <DemoBookingBase region="global" regionalContent={regionalContent} />;


### PR DESCRIPTION
Temporarily using test Calendly URL for demo booking page testing. This includes hide_event_type_details and hide_gdpr_banner parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)