### PR TITLE
Fix navigation redirecting to homepage by removing problematic redire…

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -373,11 +373,6 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
-        source: "/:dollar",
-        destination: "/",
-        permanent: true,
-      },
-      {
         source: "/case-studies/author/daniel-ge",
         destination: "/blog",
         permanent: true,


### PR DESCRIPTION
…ct pattern

The redirect pattern `/:dollar` was intended to catch the literal path `/$` but instead was treating "dollar" as a dynamic route parameter that matched ANY single-segment path like /pricing, /about, /blog, etc., redirecting them all to the homepage.

This caused all navigation links to break. Removed the redirect entirely to fix navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)